### PR TITLE
fix(cmake): avoid duplicate target creation for TwinCAT

### DIFF
--- a/cmake/FindTwinCAT.cmake
+++ b/cmake/FindTwinCAT.cmake
@@ -1,3 +1,4 @@
+
 # FindTwinCAT.cmake
 # Attempt to find TwinCAT
 #
@@ -11,10 +12,15 @@
 
 set(TwinCAT_FOUND FALSE)
 
-set(TwinCAT_API_ROOT "${TwinCAT_ROOT}/AdsApi/TcAdsDll")
+
 find_path(TwinCAT_INCLUDE_DIR
-  NAMES "TcAdsAPI.h"
-  HINTS ${TwinCAT_API_ROOT}/Include
+        NAMES "TcAdsAPI.h"
+        HINTS ${TwinCAT_API_ROOT}/Include
+)
+
+find_path(TwinCAT_INCLUDE_DIR_DEF
+        NAMES "TcAdsDef.h"
+        HINTS ${TwinCAT_API_ROOT}/Include
 )
 
 if (CMAKE_SIZEOF_VOID_P GREATER 4)
@@ -22,27 +28,30 @@ if (CMAKE_SIZEOF_VOID_P GREATER 4)
 endif ()
 
 find_library(TwinCAT_LIBRARY
-  NAMES "TcAdsDll.lib"
-  HINTS "${TwinCAT_API_ROOT}/Lib/${ARCH}"
+        NAMES "TcAdsDll.lib"
+        HINTS "${TwinCAT_API_ROOT}/Lib/${ARCH}" "${TwinCAT_API_ROOT}/${ARCH}/lib"
 )
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(TwinCAT
-  DEFAULT_MSG
-  TwinCAT_INCLUDE_DIR
-  TwinCAT_LIBRARY
+        DEFAULT_MSG
+        TwinCAT_INCLUDE_DIR
+        TwinCAT_LIBRARY
 )
 
 if(TwinCAT_FOUND)
   set(TwinCAT_INCLUDE_DIRS ${TwinCAT_INCLUDE_DIR})
   set(TwinCAT_LIBRARIES ${TwinCAT_LIBRARY})
-  add_library(TwinCAT::TwinCAT SHARED IMPORTED)
-  set_target_properties(
-    TwinCAT::TwinCAT
-    PROPERTIES
-    IMPORTED_IMPLIB "${TwinCAT_LIBRARIES}"
-    INTERFACE_INCLUDE_DIRECTORIES "${TwinCAT_INCLUDE_DIRS}"
-  )
+  if(NOT TARGET TwinCAT::TwinCAT)
+    add_library(TwinCAT::TwinCAT SHARED IMPORTED)
+    set_target_properties(
+            TwinCAT::TwinCAT
+            PROPERTIES
+            IMPORTED_IMPLIB "${TwinCAT_LIBRARIES}"
+            INTERFACE_INCLUDE_DIRECTORIES "${TwinCAT_INCLUDE_DIRS}"
+    )
+  endif()
 endif()
 
 mark_as_advanced(TwinCAT_INCLUDE_DIR TwinCAT_LIBRARY)
+

--- a/cmake/FindTwinCAT.cmake
+++ b/cmake/FindTwinCAT.cmake
@@ -12,7 +12,7 @@
 
 set(TwinCAT_FOUND FALSE)
 
-
+set(TwinCAT_API_ROOT "${TwinCAT_ROOT}/AdsApi/TcAdsDll")
 find_path(TwinCAT_INCLUDE_DIR
         NAMES "TcAdsAPI.h"
         HINTS ${TwinCAT_API_ROOT}/Include


### PR DESCRIPTION
Modified lines 45-53 to prevent the error "add_library cannot create imported target 'TwinCAT::TwinCAT' because another target with the same name already exists." 
