### PR TITLE
CMake: move handling for TwinCAT router after include target file

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,3 +1,10 @@
 @PACKAGE_INIT@
 
 include ("@PACKAGE_target_install_dest_name@")
+
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+if (USE_TWINCAT_ROUTER)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+  find_dependency(TwinCAT MODULE)
+endif()


### PR DESCRIPTION
本修改是因为，根据 https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html
<img width="553" alt="image" src="https://github.com/user-attachments/assets/ddd09a14-f644-49bd-99c3-347aede9596d" />

`PACKAGE_PREFIX_DIR` 会被[find_dependency()](https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html#command:find_dependency)改变。
而变量`PACKAGE_PREFIX_DIR` 会用在PATH_VARS对CMAKE_INSTALL_LIBDIR展开。

从而导致：`include ("@PACKAGE_target_install_dest_name@")` 会因为`PACKAGE_PREFIX_DIR`导致路径找不到而失败。